### PR TITLE
Add support for views

### DIFF
--- a/lib/active_record/annotate/dumper.rb
+++ b/lib/active_record/annotate/dumper.rb
@@ -4,8 +4,8 @@ module ActiveRecord
       class << self
         def dump(table_name, connection = ActiveRecord::Base.connection, config = ActiveRecord::Base)
           string_io = StringIO.new
-          
-          if connection.table_exists?(table_name)
+
+          if connection.table_exists?(table_name) || connection.view_exists?(table_name)
             dumper(connection, config).send(:table, table_name, string_io)
           else
             string_io.write("  # can't find table `#{table_name}`")

--- a/lib/active_record/annotate/dumper.rb
+++ b/lib/active_record/annotate/dumper.rb
@@ -5,7 +5,8 @@ module ActiveRecord
         def dump(table_name, connection = ActiveRecord::Base.connection, config = ActiveRecord::Base)
           string_io = StringIO.new
 
-          if connection.table_exists?(table_name) || connection.view_exists?(table_name)
+          if connection.table_exists?(table_name) ||
+            connection.respond_to?(:view_exists?) && connection.view_exists?(table_name)
             dumper(connection, config).send(:table, table_name, string_io)
           else
             string_io.write("  # can't find table `#{table_name}`")


### PR DESCRIPTION
Rails 5.1 made a clear distinction between views and tables, so the dumper stopped working.

Fixed it.

Some `pry`-level debugging:

```
[18] pry(main)> connection.table_exists?(table_name) || connection.view_exists?(table_name)
true
[19] pry(main)> connection.table_exists?(table_name)
false
```

Fixes #12 