### PR TITLE
Select from all possible load paths

### DIFF
--- a/lib/active_record/annotate.rb
+++ b/lib/active_record/annotate.rb
@@ -73,7 +73,7 @@ module ActiveRecord
 
       def models_dirs
         Rails.application.paths.all_paths.flat_map(&:to_a).select do |path|
-          path.include?('models')
+          path.end_with?('models')
         end
       end
 

--- a/spec/active_record/annotate_spec.rb
+++ b/spec/active_record/annotate_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper'
 
 describe ActiveRecord::Annotate do
-  describe ".short_path_for" do
+  describe '.short_path_for' do
     before(:each) do
-      allow(subject).to receive(:models_dir).and_return('dir')
+      allow(subject).to receive(:models_dirs).and_return(['dir'])
     end
-    
-    it "removes the root/app/models prefix and .rb suffix" do
+
+    it 'removes the root/app/models prefix and .rb suffix' do
       short_path = subject.short_path_for('dir/namespace/model_name.rb')
       expect(short_path).to eq('namespace/model_name')
     end
   end
-  
-  describe ".class_name_for" do
-    it "finds the class by the short path" do
+
+  describe '.class_name_for' do
+    it 'finds the class by the short path' do
       class_name = subject.class_name_for('active_record/annotate/file')
       expect(class_name).to eq(ActiveRecord::Annotate::File)
     end


### PR DESCRIPTION
Addresses #20

Background: I'm extending Rails load paths to load models from directories other than `app`. It wasn't possible to annotate models outside the default `app/models` directory, so I've implemented it

Unfortunately, I have absolutely no idea how to test it without a running Rails application, so I just manually tested it with my application and let it be

If you have any tips on how to test those things, it would be great